### PR TITLE
Deep mock & Mock Implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mock-extended",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1623,12 +1623,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1643,17 +1645,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1770,7 +1775,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1782,6 +1788,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1796,6 +1803,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1803,12 +1811,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1827,6 +1837,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1907,7 +1918,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1919,6 +1931,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2040,6 +2053,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4589,6 +4603,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "ts-essentials": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-4.0.0.tgz",
+      "integrity": "sha512-uQJX+SRY9mtbKU+g9kl5Fi7AEMofPCvHfJkQlaygpPmHPZrtgaBqbWFOYyiA47RhnSwwnXdepUJrgqUYxoUyhQ==",
+      "dev": true
     },
     "ts-jest": {
       "version": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "^24.0.23",
     "coveralls": "^3.0.7",
     "jest": "^24.9.0",
+    "ts-essentials": "^4.0.0",
     "prettier": "^1.19.1",
     "ts-jest": "^24.1.0",
     "typescript": "^3.7.2"

--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -8,7 +8,9 @@ interface CalledWithStackItem<T, Y extends any[]> {
 
 const checkCalledWith = <T, Y extends any[]>(calledWithStack: CalledWithStackItem<T, Y>[], actualArgs: Y): T => {
     const calledWithInstance = calledWithStack.find(instance =>
-        instance.args.every((matcher, i) => (matcher instanceof Matcher ? matcher.asymmetricMatch(actualArgs[i]) : actualArgs[i] === matcher))
+        instance.args.every((matcher, i) =>
+            matcher instanceof Matcher ? matcher.asymmetricMatch(actualArgs[i]) : actualArgs[i] === matcher
+        )
     );
 
     // @ts-ignore cannot return undefined, but this will fail the test if there is an expectation which is what we want

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -8,35 +8,55 @@ interface MockInt {
     getSomethingWithArgs: (arg1: number, arg2: number) => number;
 }
 
+class Test1 implements MockInt {
+    readonly id: number;
+    private readonly anotherPart: number;
+    public deepProp: Test2 = new Test2();
+
+    constructor(id: number) {
+        this.id = id;
+        this.anotherPart = id;
+    }
+
+    ofAnother(test: Test1) {
+        return test.getNumber();
+    }
+
+    getNumber() {
+        return this.id;
+    }
+
+    getSomethingWithArgs(arg1: number, arg2: number) {
+        return this.id;
+    }
+}
+
+class Test2 {
+    getNumber(num: number) {
+        return num * 2;
+    }
+}
+
 describe('jest-mock-extended', () => {
     test('Can be assigned back to itself even when there are private parts', () => {
-        class Test1 implements MockInt {
-            readonly id: number;
-            private readonly anotherPart: number;
-
-            constructor(id: number) {
-                this.id = id;
-                this.anotherPart = id;
-            }
-
-            ofAnother(test: Test1) {
-                return test.getNumber();
-            }
-
-            getNumber() {
-                return this.id;
-            }
-
-            getSomethingWithArgs(arg1: number, arg2: number) {
-                return this.id;
-            }
-        }
-
         // No TS errors here
         const mockObj: Test1 = mock<Test1>();
         // No error here.
         new Test1(1).ofAnother(mockObj);
         expect(mockObj.getNumber).toHaveBeenCalledTimes(1);
+    });
+
+    test('can deep mock members', () => {
+        const mockObj = mock<Test1>(true);
+        mockObj.deepProp.getNumber.calledWith(1).mockReturnValue(4);
+        expect(mockObj.deepProp.getNumber(1)).toBe(4);
+    });
+
+    test('maintains API for deep mocks', () => {
+        const mockObj = mock<Test1>(true);
+        mockObj.deepProp.getNumber(100);
+
+        expect(mockObj.deepProp.getNumber.mock.calls[0][0]).toBe(100);
     });
 
     test('Check that a jest.fn() is created without any invocation to the mock method', () => {

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -31,15 +31,8 @@ class Test1 implements MockInt {
     }
 }
 
-class Test3 {
-    getNumber(num: number) {
-        return num ^ 2;
-    }
-}
-
 class Test2 {
     public deeperProp: Test3 = new Test3();
-
 
     getNumber(num: number) {
         return num * 2;
@@ -50,10 +43,16 @@ class Test2 {
     }
 }
 
+class Test3 {
+    getNumber(num: number) {
+        return num ^ 2;
+    }
+}
+
 describe('jest-mock-extended', () => {
     test('Can be assigned back to itself even when there are private parts', () => {
         // No TS errors here
-        const mockObj: Test1 = mockDeep<Test1>();
+        const mockObj: Test1 = mock<Test1>();
         // No error here.
         new Test1(1).ofAnother(mockObj);
         expect(mockObj.getNumber).toHaveBeenCalledTimes(1);
@@ -189,6 +188,18 @@ describe('jest-mock-extended', () => {
             mockObj.deepProp.getNumber(100);
 
             expect(mockObj.deepProp.getNumber.mock.calls[0][0]).toBe(100);
+        });
+
+        test('non deep expectation work as expected', () => {
+            const mockObj = mockDeep<Test1>();
+            new Test1(1).ofAnother(mockObj);
+            expect(mockObj.getNumber).toHaveBeenCalledTimes(1);
+        });
+
+        test('deep expectation work as expected', () => {
+            const mockObj = mockDeep<Test1>();
+            mockObj.deepProp.getNumber(2);
+            expect(mockObj.deepProp.getNumber).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -13,85 +13,76 @@ export type MockProxy<T> = {
     [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> & T[K] : MockProxy<T[K]> & T[K];
 };
 
-const JestFnAPI = [
-    '_isMockFunction',
-    '_protoImpl',
-    'getMockName',
-    'getMockImplementation',
-    'mock',
-    'mockClear',
-    'mockReset',
-    'mockRestore',
-    'mockImplementation',
-    'mockImplementation',
-    'mockImplementationOnce',
-    'mockImplementationOnce',
-    'mockName',
-    'mockReturnThis',
-    'mockReturnValue',
-    'mockReturnValueOnce',
-    'mockResolvedValue',
-    'mockResolvedValueOnce',
-    'mockRejectedValue',
-    'mockRejectedValueOnce',
-    'calledWith' // added by this library
-];
-
 export interface MockOpts {
     deep?: boolean;
 }
 
 export const mockDeep = <T>(mockImplementation?: DeepPartial<T>): MockProxy<T> & T => mock(mockImplementation, { deep: true });
 
-const mock = <T>(mockImplementation: DeepPartial<T> = {} as DeepPartial<T>, opts?: MockOpts): MockProxy<T> & T => {
-    const handler = {
-        set: (obj: MockProxy<T>, property: ProxiedProperty, value: any) => {
-            // @ts-ignore
-            obj[property] = value;
-            return true;
-        },
 
-        get: (obj: MockProxy<T>, property: ProxiedProperty) => {
-            let fn = calledWithFn();
+// @ts-ignore
+const overrideMockImp =  (obj: object, opts) => {
+    // @ts-ignore
+    console.info('in override', obj);
+    const proxy = new Proxy<MockProxy<any>>(obj, handler(opts));
+        for (let name of Object.keys(obj)) {
             // @ts-ignore
-            if (!obj[property]) {
-                if (opts?.deep) {
+            if (typeof obj[name] === 'object' && obj[name] !== null) {
+                // @ts-ignore
+                console.info(name);
+                // @ts-ignore
+                proxy[name] = overrideMockImp(obj[name])
+            } else {
+                // @ts-ignore
+                proxy[name] = obj[name];
+            }
+        }
+
+    return proxy;
+}
+
+
+const handler = (opts?: MockOpts) => ({
+    set: (obj: MockProxy<any>, property: ProxiedProperty, value: any) => {
+        // @ts-ignore
+        obj[property] = value;
+        return true;
+    },
+
+    get: (obj: MockProxy<any>, property: ProxiedProperty) => {
+        let fn = calledWithFn();
+        // @ts-ignore
+        console.info('boom', property, obj[property]);
+
+        // @ts-ignore
+        if (!obj[property]) {
+            if (opts?.deep) {
+                // @ts-ignore
+                console.info('deeeep', property, obj);
+
+                // @ts-ignore
+                fn.propName = property;
+                // @ts-ignore
+                obj[property] = new Proxy<MockProxy<T>>(fn, handler(opts));
+            } else {
+                // @ts-ignore
+                console.info('raw');
+                // @ts-ignore
+                if (!obj[property]) {
                     // @ts-ignore
-                    fn.propName = property;
-                    // @ts-ignore
-                    obj[property] = new Proxy<MockProxy<T>>(fn, handler);
-                } else {
-                    // @ts-ignore
-                    if (!obj[property]) {
-                        // @ts-ignore
-                        obj[property] = calledWithFn();
-                    }
+                    obj[property] = calledWithFn();
                 }
             }
-            // @ts-ignore
-            return obj[property];
-        },
-        apply: (obj: MockProxy<T>, thisArg: any, argumentsList: Array<any>) => {
-            // check to see if this is a call on a the MockInstance which we will need to delegate to the instance rather
-            // than the function i.e
-            // const mock = jest.fn();
-            // mock.mockReturnValue() // Call on instance
-            // mock(); // call on mock function
-            // TODO: There does not seem to be a cleaner way to do this - any suggestions?
-
-            // @ts-ignore
-            if (JestFnAPI.includes(obj.propName)) {
-                // @ts-ignore
-                return obj[obj.propName](...argumentsList);
-            }
-
-            // otherwise it's a call on the mock function.
-            // @ts-ignore
-            return obj(...argumentsList);
         }
-    };
+        // @ts-ignore
+        return obj[property];
+    }
+});
 
-    return new Proxy<MockProxy<T>>(mockImplementation as MockProxy<T>, handler);
+
+const mock = <T>(mockImplementation: DeepPartial<T> = {} as DeepPartial<T>, opts?: MockOpts): MockProxy<T> & T => {
+    // @ts-ignore
+    return overrideMockImp(mockImplementation, opts);
 };
 
 export default mock;

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -20,18 +20,18 @@ export interface MockOpts {
 export const mockDeep = <T>(mockImplementation?: DeepPartial<T>): MockProxy<T> & T => mock(mockImplementation, { deep: true });
 
 // @ts-ignore
-const overrideMockImp =  (obj: object, opts) => {
+const overrideMockImp = (obj: object, opts) => {
     const proxy = new Proxy<MockProxy<any>>(obj, handler(opts));
-        for (let name of Object.keys(obj)) {
+    for (let name of Object.keys(obj)) {
+        // @ts-ignore
+        if (typeof obj[name] === 'object' && obj[name] !== null) {
             // @ts-ignore
-            if (typeof obj[name] === 'object' && obj[name] !== null) {
-                // @ts-ignore
-                proxy[name] = overrideMockImp(obj[name])
-            } else {
-                // @ts-ignore
-                proxy[name] = obj[name];
-            }
+            proxy[name] = overrideMockImp(obj[name]);
+        } else {
+            // @ts-ignore
+            proxy[name] = obj[name];
         }
+    }
 
     return proxy;
 };
@@ -69,7 +69,6 @@ const handler = (opts?: MockOpts) => ({
         return obj[property];
     }
 });
-
 
 const mock = <T>(mockImplementation: DeepPartial<T> = {} as DeepPartial<T>, opts?: MockOpts): MockProxy<T> & T => {
     // @ts-ignore

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -19,17 +19,12 @@ export interface MockOpts {
 
 export const mockDeep = <T>(mockImplementation?: DeepPartial<T>): MockProxy<T> & T => mock(mockImplementation, { deep: true });
 
-
 // @ts-ignore
 const overrideMockImp =  (obj: object, opts) => {
-    // @ts-ignore
-    console.info('in override', obj);
     const proxy = new Proxy<MockProxy<any>>(obj, handler(opts));
         for (let name of Object.keys(obj)) {
             // @ts-ignore
             if (typeof obj[name] === 'object' && obj[name] !== null) {
-                // @ts-ignore
-                console.info(name);
                 // @ts-ignore
                 proxy[name] = overrideMockImp(obj[name])
             } else {
@@ -39,8 +34,7 @@ const overrideMockImp =  (obj: object, opts) => {
         }
 
     return proxy;
-}
-
+};
 
 const handler = (opts?: MockOpts) => ({
     set: (obj: MockProxy<any>, property: ProxiedProperty, value: any) => {
@@ -51,22 +45,19 @@ const handler = (opts?: MockOpts) => ({
 
     get: (obj: MockProxy<any>, property: ProxiedProperty) => {
         let fn = calledWithFn();
-        // @ts-ignore
-        console.info('boom', property, obj[property]);
 
         // @ts-ignore
         if (!obj[property]) {
-            if (opts?.deep) {
-                // @ts-ignore
-                console.info('deeeep', property, obj);
-
+            // So this calls check here is totally not ideal - jest internally does a
+            // check to see if this is a spy - which we want to say no to, but blindly returning
+            // an proxy for calls results in the spy check returning true. This is another reason
+            // why deep is opt in.
+            if (opts?.deep && property !== 'calls') {
                 // @ts-ignore
                 fn.propName = property;
                 // @ts-ignore
-                obj[property] = new Proxy<MockProxy<T>>(fn, handler(opts));
+                obj[property] = new Proxy<MockProxy<any>>(fn, handler(opts));
             } else {
-                // @ts-ignore
-                console.info('raw');
                 // @ts-ignore
                 if (!obj[property]) {
                     // @ts-ignore

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -59,10 +59,7 @@ const handler = (opts?: MockOpts) => ({
                 obj[property] = new Proxy<MockProxy<any>>(fn, handler(opts));
             } else {
                 // @ts-ignore
-                if (!obj[property]) {
-                    // @ts-ignore
-                    obj[property] = calledWithFn();
-                }
+                obj[property] = calledWithFn();
             }
         }
         // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default as mock, MockProxy, CalledWithMock } from './Mock';
+export { default as mock, mockDeep, MockProxy, CalledWithMock } from './Mock';
 export { default as calledWithFn } from './CalledWithFn';
 export * from './Matchers';


### PR DESCRIPTION
Some API Additions to support deep mocks and mock implementations. Note that this should not affect any existing usages of the API

Deep Mocks

```ts
test('can deep mock members', () => {
   const mockObj = mockDeep<Test1>();
   mockObj.deepProp.getNumber.calledWith(1).mockReturnValue(4);
   expect(mockObj.deepProp.getNumber(1)).toBe(4);
});
```

Mock Implementations

```ts
const mockObj = mock<Test1>({
      id: 61
});
expect(mockObj.id).toBe(61);
```

Deep Mocks with mock implementation
```ts
const mockObj = mockDeep<Test1>({
     deepProp: {
         getNumber: (num: number) => {
              return 76;
         }
     }
});
expect(mockObj.deepProp.getNumber(123)).toBe(76);
```