### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ describe('Party Tests', () => {
    
    
    test('mock out a return type', () => {
-       const mock = mock<FunProvider>();
+       const mock = mock<PartyProvider>();
        mock.getPartyType.mockReturnValue('west coast party');
        
        expect(mock.getPartyType()).toBe('west coast party');


### PR DESCRIPTION
Looks like the interface in the second example should be `PartyProvider` and not `FunProvider`.