### PR TITLE
Permit jest 25 as a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
-    "jest": "^24.0.0"
+    "jest": "^24.0.0 || ^25.0.0"
   },
   "author": "Marc McIntyre <marchaos@gmail.com>",
   "license": "MIT"


### PR DESCRIPTION
Gets rid of a warning from npm about an unmet peer when upgrading downstream to Jest 25.

Alternative semver range for consideration: `>23 <26` (though this project should work fine with versions as far back as 14 I think based on the jest change log). Also considered `>23 <25.3.0`