### PR TITLE
feature: allow null and boolean properties

### DIFF
--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -119,6 +119,14 @@ describe('jest-mock-extended', () => {
         expect(mockObj2.someValue).toBe(null);
     });
 
+    test('can set undefined explicitly', () => {
+        const mockObj = mock<MockInt>({
+            someValue: undefined // this is intentionally set to undefined
+        });
+
+        expect(mockObj.someValue).toBe(undefined);
+    });
+
     describe('calledWith', () => {
         test('can use calledWith without mock', () => {
             const mockFn = calledWithFn();

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -4,6 +4,7 @@ import calledWithFn from './CalledWithFn';
 
 interface MockInt {
     id: number;
+    someValue?: boolean | null;
     getNumber: () => number;
     getSomethingWithArgs: (arg1: number, arg2: number) => number;
 }
@@ -103,6 +104,19 @@ describe('jest-mock-extended', () => {
         mockObj.id = 17;
 
         expect(mockObj.id).toBe(17);
+    });
+
+    test('Can set false and null boolean props', () => {
+        const mockObj = mock<MockInt>({
+            someValue: false
+        });
+
+        const mockObj2 = mock<MockInt>({
+            someValue: null
+        });
+
+        expect(mockObj.someValue).toBe(false);
+        expect(mockObj2.someValue).toBe(null);
     });
 
     describe('calledWith', () => {

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -83,7 +83,7 @@ const handler = (opts?: MockOpts) => ({
         let fn = calledWithFn();
 
         // @ts-ignore
-        if (!obj[property]) {
+        if (typeof obj[property] === 'undefined') {
             // This condition is required to use the mock object in the promise.
             // For example Promise.resolve (layout) and async return values.
             // These solutions check the "then" property.

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -83,7 +83,7 @@ const handler = (opts?: MockOpts) => ({
         let fn = calledWithFn();
 
         // @ts-ignore
-        if (typeof obj[property] === 'undefined') {
+        if (!(property in obj)) {
             // This condition is required to use the mock object in the promise.
             // For example Promise.resolve (layout) and async return values.
             // These solutions check the "then" property.


### PR DESCRIPTION
👋  Thanks for you work on this library! I noticed that I cannot set boolean values due to the conditional statement checking for falsey values.

#### Related Issues
I believe https://github.com/marchaos/jest-mock-extended/issues/30 would be fixed by this change. It appears as though the author is running into the same scenario I did.

#### The Fix
I changed the condition to check only for undefined, which would allow boolean and null values to be used.


Let me know if there is anything you'd like me to adjust! Thanks 🙌 