### PR TITLE
Ensure mocks pass jest equality tests

### DIFF
--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -105,6 +105,16 @@ describe('jest-mock-extended', () => {
         expect(mockObj.id).toBe(17);
     });
 
+    test('Equals self', () => {
+        const mockObj = mock<MockInt>();
+        expect(mockObj).toBe(mockObj);
+        expect(mockObj).toEqual(mockObj);
+
+        const spy = jest.fn();
+        spy(mockObj);
+        expect(spy).toHaveBeenCalledWith(mockObj);
+    });
+
     describe('calledWith', () => {
         test('can use calledWith without mock', () => {
             const mockFn = calledWithFn();

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -91,6 +91,11 @@ const handler = (opts?: MockOpts) => ({
             if (property === 'then') {
                 return undefined;
             }
+            // Jest's internal equality checking does some wierd stuff to check for iterable equality
+            if (property === Symbol.iterator) {
+                // @ts-ignore
+                return obj[property];
+            }
             // So this calls check here is totally not ideal - jest internally does a
             // check to see if this is a spy - which we want to say no to, but blindly returning
             // an proxy for calls results in the spy check returning true. This is another reason


### PR DESCRIPTION
Fixes: #9 & #28 

In Jest 24.x this presents as "Cannot read property 'next' of undefined"
In Jest 25.x & Jest 26.x this presents as "TypeError: Result of the Symbol.iterator method is not an object"
This patch works for all 3 versions. 

I've also checked it works with PR #33 (and is still needed even if that gets merged).

@marchaos Thanks for all your work on this. Really neat package :partying_face: 