### PR TITLE
Bump version for mockFn release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mock-extended",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "homepage": "https://github.com/marchaos/jest-mock-extended",
   "description": "Type safe mocking extensions for jest",
   "files": [


### PR DESCRIPTION
The recently added `mockFn` export looks useful. Could you kindly release a new version so we can use it?