### PR TITLE
Indicate the mock is a class instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Ability to mock any interface or object
 - calledWith() extension to provide argument specific expectations, which works for objects and functions.
 - Extensive Matcher API compatible with Jasmine matchers
-- Supports mocking deep objects / classes.
+- Supports mocking deep objects / class instances.
 - Familiar Jest like API
 
 ## Installation


### PR DESCRIPTION
In trying to mock a class we discovered it only creates a mock instance and doesn't not mock the constructor