### PR TITLE
Add jest 27.0.0 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
-    "jest": "^24.0.0 || ^25.0.0 || ^26.0.0",
+    "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0",
     "typescript": "^3.0.0 || ^4.0.0"
   },
   "author": "Marc McIntyre <marchaos@gmail.com>",


### PR DESCRIPTION
To avoid installation failure like this:

```bash 
 npm ERR! Found: jest@27.0.1
npm ERR! node_modules/jest
npm ERR!   dev jest@"^27.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer jest@"^24.0.0 || ^25.0.0 || ^26.0.0" from jest-mock-extended@1.0.15
npm ERR! node_modules/jest-mock-extended
npm ERR!   dev jest-mock-extended@"^1.0.13" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```