### PR TITLE
Export DeepMockProxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
     GlobalConfig,
     mockDeep,
     MockProxy,
+    DeepMockProxy,
     CalledWithMock,
     mockClear,
     mockReset,


### PR DESCRIPTION
Need this since the breaking change of v2 (I used to store it in a MockProxy).