### PR TITLE
fix(calledWith) prevent falsy jestAsymmetricMatcher detection for Mock

### DIFF
--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -10,11 +10,11 @@ interface JestAsymmetricMatcher {
     asymmetricMatch(...args: any[]): boolean;
 }
 function isJestAsymmetricMatcher(obj: any): obj is JestAsymmetricMatcher {
-    return !!obj && !!obj.asymmetricMatch && typeof obj.asymmetricMatch === 'function';
+    return !!obj && typeof obj === 'object' && 'asymmetricMatch' in obj && typeof obj.asymmetricMatch === 'function';
 }
 
 const checkCalledWith = <T, Y extends any[]>(calledWithStack: CalledWithStackItem<T, Y>[], actualArgs: Y): T => {
-    const calledWithInstance = calledWithStack.find((instance) =>
+    const calledWithInstance = calledWithStack.find(instance =>
         instance.args.every((matcher, i) => {
             if (matcher instanceof Matcher) {
                 return matcher.asymmetricMatch(actualArgs[i]);

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -7,6 +7,7 @@ interface MockInt {
     id: number;
     someValue?: boolean | null;
     getNumber: () => number;
+    getNumberWithMockArg: (mock: any) => number;
     getSomethingWithArgs: (arg1: number, arg2: number) => number;
     getSomethingWithMoreArgs: (arg1: number, arg2: number, arg3: number) => number;
 }
@@ -26,6 +27,10 @@ class Test1 implements MockInt {
     }
 
     public getNumber() {
+        return this.id;
+    }
+
+    public getNumberWithMockArg(mock: any) {
         return this.id;
     }
 
@@ -214,6 +219,14 @@ describe('jest-mock-extended', () => {
             expect(mockObj.getSomethingWithMoreArgs(1, 2, 3)).toBe(4);
             expect(mockObj.getSomethingWithMoreArgs(1, 2, 4)).toBeUndefined;
         });
+
+        test('Can use calledWith with an other mock', () => {
+            const mockObj = mock<MockInt>();
+            const mockArg = mock();
+            mockObj.getNumberWithMockArg.calledWith(mockArg).mockReturnValue(4);
+
+            expect(mockObj.getNumberWithMockArg(mockArg)).toBe(4);
+        })
     });
 
     describe('Matchers with toHaveBeenCalledWith', () => {


### PR DESCRIPTION
If a mock was passed to the calledWith function as an argument, it was falsely detected as a `Jest Asymmetric Matcher`.

This PR change this by using the `in` keyword, which does not trigger the proxy.

A test has been added to demonstrate the new behavior.