### PR TITLE
Fix TypeError thrown in mockReset/mockClear

### DIFF
--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -429,6 +429,42 @@ describe('jest-mock-extended', () => {
             // Does not clear mock implementations of calledWith
             expect(mockObj.deepProp.getNumber(1)).toBe(4);
         });
+
+        test('mockReset ignores undefined properties', () => {
+            const mockObj = mock<MockInt>();
+            mockObj.someValue = undefined;
+            mockObj.getSomethingWithArgs.calledWith(1, anyNumber()).mockReturnValue(3);
+            mockReset(mockObj);
+            expect(mockObj.getSomethingWithArgs(1, 2)).toBe(undefined);
+        });
+
+        test('mockReset ignores null properties', () => {
+            const mockObj = mock<MockInt>();
+            mockObj.someValue = null;
+            mockObj.getSomethingWithArgs.calledWith(1, anyNumber()).mockReturnValue(3);
+            mockReset(mockObj);
+            expect(mockObj.getSomethingWithArgs(1, 2)).toBe(undefined);
+        });
+
+        test('mockClear ignores undefined properties', () => {
+            const mockObj = mock<MockInt>();
+            mockObj.someValue = undefined;
+            mockObj.getSomethingWithArgs.calledWith(1, anyNumber()).mockReturnValue(3);
+            expect(mockObj.getSomethingWithArgs(1, 2)).toBe(3);
+            expect(mockObj.getSomethingWithArgs.mock.calls.length).toBe(1);
+            mockClear(mockObj);
+            expect(mockObj.getSomethingWithArgs.mock.calls.length).toBe(0);
+        });
+
+        test('mockClear ignores null properties', () => {
+            const mockObj = mock<MockInt>();
+            mockObj.someValue = null;
+            mockObj.getSomethingWithArgs.calledWith(1, anyNumber()).mockReturnValue(3);
+            expect(mockObj.getSomethingWithArgs(1, 2)).toBe(3);
+            expect(mockObj.getSomethingWithArgs.mock.calls.length).toBe(1);
+            mockClear(mockObj);
+            expect(mockObj.getSomethingWithArgs.mock.calls.length).toBe(0);
+        });
     });
 
     describe('function mock', () => {

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -48,6 +48,8 @@ export interface MockOpts {
 
 export const mockClear = (mock: MockProxy<any>) => {
     for (let key of Object.keys(mock)) {
+        if (mock[key] == null) continue;
+        
         if (mock[key]._isMockObject) {
             mockClear(mock[key]);
         }
@@ -65,6 +67,8 @@ export const mockClear = (mock: MockProxy<any>) => {
 
 export const mockReset = (mock: MockProxy<any>) => {
     for (let key of Object.keys(mock)) {
+        if (mock[key] == null) continue;
+
         if (mock[key]._isMockObject) {
             mockReset(mock[key]);
         }


### PR DESCRIPTION
This patch fixes the bug where TypeError is thrown in `mockReset`/`mockClear` when the mock has properties with `null` or `undefined` values.

I encounter this bug when using `jest-mock-extended` along with `jest-when` (https://github.com/timkindberg/jest-when/blob/master/src/when.js#L204). 
`jest-when` internally uses `__whenMock__` property to store the mock setup, and assign `undefined` to this once the mock is reset. Calling `mockClear` or `mockReset` after that would throw TypeError exception.