### PR TITLE
Explicitly Show DeepMockProxy<T> In Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ replacement for mock.
 ```ts
 import { mockDeep } from 'jest-mock-extended';
 
-const mockObj = mockDeep<Test1>();
+const mockObj: DeepMockProxy<Test1> = mockDeep<Test1>();
 mockObj.deepProp.getNumber.calledWith(1).mockReturnValue(4);
 expect(mockObj.deepProp.getNumber(1)).toBe(4);
 ```


### PR DESCRIPTION
It took me a moment to figure out that the `MockProxy<T>` type mentioned earlier _should't_ be used in this case.