### PR TITLE
Fix DeepMockProxy type error for objects which are functions and have fields at the same time

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -35,19 +35,9 @@ export type MockProxy<T> = {
     [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : T[K];
 } & T;
 
-// Make a type by omitting keys which match Condition
-export type OmitType<Base, Condition> = Omit<
-    Base,
-    {
-        [Key in keyof Base]: Base[Key] extends Condition ? never : Key;
-    }[keyof Base]
->;
-
 export type DeepMockProxy<T> = {
     // This supports deep mocks in the else branch
-    [K in keyof T]: T[K] extends (...args: infer A) => infer B
-        ? CalledWithMock<B, A> & DeepMockProxy<OmitType<T[K], (...args: any) => any>>
-        : DeepMockProxy<T[K]>;
+    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> & DeepMockProxy<T[K]> : DeepMockProxy<T[K]>;
 } & T;
 
 export interface MockOpts {

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -33,14 +33,22 @@ export interface CalledWithMock<T, Y extends any[]> extends jest.Mock<T, Y> {
 export type MockProxy<T> = {
     // This supports deep mocks in the else branch
     [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : T[K];
-} &
-    T;
+} & T;
+
+// Make a type by omitting keys which match Condition
+export type OmitType<Base, Condition> = Omit<
+    Base,
+    {
+        [Key in keyof Base]: Base[Key] extends Condition ? never : Key;
+    }[keyof Base]
+>;
 
 export type DeepMockProxy<T> = {
     // This supports deep mocks in the else branch
-    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : DeepMockProxy<T[K]>;
-} &
-    T;
+    [K in keyof T]: T[K] extends (...args: infer A) => infer B
+        ? CalledWithMock<B, A> & DeepMockProxy<OmitType<T[K], (...args: any) => any>>
+        : DeepMockProxy<T[K]>;
+} & T;
 
 export interface MockOpts {
     deep?: boolean;
@@ -89,7 +97,7 @@ export const mockReset = (mock: MockProxy<any>) => {
     }
 };
 
-export const mockDeep = <T>(mockImplementation?: DeepPartial<T>): DeepMockProxy<T> & T => mock(mockImplementation, { deep: true });
+export const mockDeep = <T>(mockImplementation?: DeepPartial<T>) => mock<T, DeepMockProxy<T> & T>(mockImplementation, { deep: true });
 
 const overrideMockImp = (obj: DeepPartial<any>, opts?: MockOpts) => {
     const proxy = new Proxy<MockProxy<any>>(obj, handler(opts));
@@ -154,7 +162,10 @@ const handler = (opts?: MockOpts) => ({
     },
 });
 
-const mock = <T>(mockImplementation: DeepPartial<T> = {} as DeepPartial<T>, opts?: MockOpts): MockProxy<T> & T => {
+const mock = <T, MockedReturn extends MockProxy<T> & T = MockProxy<T> & T>(
+    mockImplementation: DeepPartial<T> = {} as DeepPartial<T>,
+    opts?: MockOpts
+): MockedReturn => {
     // @ts-ignore private
     mockImplementation!._isMockObject = true;
     return overrideMockImp(mockImplementation, opts);


### PR DESCRIPTION
For some types like `AxiosInstance` the object (or rather better called as a function that has fields) doubles as function. This means that in the current type implementation for DeepMockProxy the if condition gets triggered for the function part. This causes the type to incorrectly say that only the first nested field is possible. To show this in action I am putting a simplified version similar to how `AxiosInstance` behaves when used inside a class. You can find the original implementation of `AxiosInstance` [here](https://github.com/axios/axios/blob/bdf493cf8b84eb3e3440e72d5725ba0f138e0451/index.d.ts#L371)

```ts
import { CalledWithMock, DeepMockProxy } from './Mock';

interface DemoInter {
    (config: Record<string, any>): Promise<any>;
    (url: string, config?: Record<string, any>): Promise<any>;

    request(inp: string): Promise<any>;

    dataField: {
        hello: 'world';
    };
}

class DemoClass {
    client: DemoInter;

    constructor(a: DemoInter) {
        this.client = a;
    }
}

type OldDeepMockProxy<T> = {
    // This supports deep mocks in the else branch
    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : OldDeepMockProxy<T[K]>;
} & T;

let oldMock: OldDeepMockProxy<DemoClass>;

// This would fail compilation with existing DeepMockProxy
oldMock.client.request.mockImplementationOnce();

let newMock: DeepMockProxy<DemoClass>;

// This is properly typed
newMock.client.request.mockImplementationOnce();

// Properly works for other data fields
newMock.client.dataField.hello;

```

This PR fixes #94 