### PR TITLE
allow overriding calledWithFn

### DIFF
--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -45,7 +45,7 @@ export const calledWithFn = <T, Y extends any[]>(): CalledWithMock<T, Y> => {
             fn.mockImplementation((...args: Y) => checkCalledWith(calledWithStack, args));
             calledWithStack = [];
         }
-        calledWithStack.push({ args, calledWithFn });
+        calledWithStack.unshift({ args, calledWithFn });
 
         return calledWithFn;
     };

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -205,6 +205,14 @@ describe('jest-mock-extended', () => {
             expect(mockObj.getSomethingWithArgs(7, 2)).toBe(undefined);
         });
 
+        test('supports overriding with same args', () => {
+            const mockObj = mock<MockInt>();
+            mockObj.getSomethingWithArgs.calledWith(1, 2).mockReturnValue(4);
+            mockObj.getSomethingWithArgs.calledWith(1, 2).mockReturnValue(3);
+
+            expect(mockObj.getSomethingWithArgs(1, 2)).toBe(3);
+        })
+
         test('Support jest matcher', () => {
             const mockObj = mock<MockInt>();
             mockObj.getSomethingWithArgs.calledWith(expect.anything(), expect.anything()).mockReturnValue(3);


### PR DESCRIPTION
By using `unshift` instead of `push`, new callbacks are added to the "top" of the stack (since `find` searches from the beginning of the array). This allow a second call to `calledWith()` to override a previous call. This is useful for one-off tests.

Fixes #77.