### PR TITLE
Add support for providing fallbackMockImplementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ describe('Party Tests', () => {
        
        expect(mock.getPartyType()).toBe('west coast party');
    });
-});
+
+    test('throwing an error if we forget to specify the return value')
+        const mock = mock<PartyProvider>(
+            {},
+            {
+                fallbackMockImplementation: () => {
+                    throw new Error('not mocked');
+                },
+            }
+        );
+
+        expect(() => mock.getPartyType()).toThrowError('not mocked');
+    });
 ```
 
 ## Assigning Mocks with a Type

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ expect(mockObj.deepProp(1)).toBe(3);
 expect(mockObj.deepProp.getNumber(1)).toBe(4);
 ```
 
+Can can provide a fallback mock implementation used if you do not define a return value using `calledWith`.
+
+```ts
+import { mockDeep } from 'jest-mock-extended';
+const mockObj = mockDeep<Test1>({
+    fallbackMockImplementation: () => {
+        throw new Error('please add expected return value using calledWith');
+    },
+});
+expect(() => mockObj.getNumber()).toThrowError('not mocked');
+```
+
+
 ## Available Matchers
 
 

--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -32,14 +32,16 @@ const checkCalledWith = <T, Y extends any[]>(calledWithStack: CalledWithStackIte
     return calledWithInstance ? calledWithInstance.calledWithFn(...actualArgs) : undefined;
 };
 
-export const calledWithFn = <T, Y extends any[]>(): CalledWithMock<T, Y> => {
-    const fn: jest.Mock<T, Y> = jest.fn();
+export const calledWithFn = <T, Y extends any[]>({
+    fallbackMockImplementation,
+}: { fallbackMockImplementation?: (...args: Y) => T } = {}): CalledWithMock<T, Y> => {
+    const fn: jest.Mock<T, Y> = jest.fn(fallbackMockImplementation);
     let calledWithStack: CalledWithStackItem<T, Y>[] = [];
 
     (fn as CalledWithMock<T, Y>).calledWith = (...args) => {
         // We create new function to delegate any interactions (mockReturnValue etc.) to for this set of args.
         // If that set of args is matched, we just call that jest.fn() for the result.
-        const calledWithFn = jest.fn();
+        const calledWithFn = jest.fn(fallbackMockImplementation);
         if (!fn.getMockImplementation()) {
             // Our original function gets a mock implementation which handles the matching
             fn.mockImplementation((...args: Y) => checkCalledWith(calledWithStack, args));

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -124,6 +124,19 @@ describe('jest-mock-extended', () => {
         expect(mockObj.getSomethingWithArgs(1, 2)).toBe(1);
     });
 
+    test('Can specify fallbackMockImplementation', () => {
+        const mockObj = mock<MockInt>(
+            {},
+            {
+                fallbackMockImplementation: () => {
+                    throw new Error('not mocked');
+                },
+            }
+        );
+
+        expect(() => mockObj.getSomethingWithArgs(1, 2)).toThrowError('not mocked');
+    });
+
     test('Can specify multiple calledWith', () => {
         const mockObj = mock<MockInt>();
         mockObj.getSomethingWithArgs.calledWith(1, 2).mockReturnValue(3);

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -308,6 +308,32 @@ describe('jest-mock-extended', () => {
             mockObj.deepProp.getNumber(2);
             expect(mockObj.deepProp.getNumber).toHaveBeenCalledTimes(1);
         });
+
+        test('fallback mock implementation can be overridden', () => {
+            const mockObj = mockDeep<Test1>({
+                fallbackMockImplementation: () => {
+                    throw new Error('not mocked');
+                },
+            });
+            expect(() => mockObj.getNumber()).toThrowError('not mocked');
+        });
+
+        test('fallback mock implementation can be overridden while also providing a mock implementation', () => {
+            const mockObj = mockDeep<Test1>(
+                {
+                    fallbackMockImplementation: () => {
+                        throw new Error('not mocked');
+                    },
+                },
+                {
+                    getNumber: () => {
+                        return 150;
+                    },
+                }
+            );
+            expect(mockObj.getNumber()).toBe(150);
+            expect(() => mockObj.deepProp.getNumber(1)).toThrowError('not mocked');
+        });
     });
 
     describe('Deep mock support for class variables which are functions but also have nested properties and functions', () => {


### PR DESCRIPTION
Solves https://github.com/marchaos/jest-mock-extended/issues/106 https://github.com/marchaos/jest-mock-extended/issues/102

This PR adds support for providing a `fallbackMockImplementation` for `mock` and `deepMock`. My primary motivation is to throw in case a mock implementation is not provided.