### PR TITLE
Update typescript to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "devDependencies": {
     "@types/jest": "^27.5.0",
     "coveralls": "^3.1.1",
-    "jest": "^29.0.0",
+    "jest": "^29.5.0",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
-    "ts-jest": "^28.0.1",
+    "ts-jest": "^29.0.5",
     "typescript": "^4.3.5"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.3.5"
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
-    "typescript": "^3.0.0 || ^4.0.0"
+    "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "author": "Marc McIntyre <marchaos@gmail.com>",
   "license": "MIT"


### PR DESCRIPTION
This dependency is the only one blocking us to update to typescript v5 😃 

It passes all the test!

(I also updated the jest dependencies because that errored for me on install)

Fixes #112 