### PR TITLE
Replace usage of Jest globals with @jest/globals package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ts-essentials": "^7.0.3"
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ts-essentials": "^7.0.3"
   },
   "devDependencies": {
-    "@types/jest": "^27.5.0",
     "coveralls": "^3.1.1",
     "jest": "^29.5.0",
     "prettier": "^2.3.2",
@@ -32,6 +31,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
+    "@jest/globals": "^28.0.0 || ^29.0.0",
     "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
     "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },

--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -1,9 +1,11 @@
 import { CalledWithMock } from './Mock';
 import { Matcher, MatchersOrLiterals } from './Matchers';
+import { jest } from '@jest/globals';
+import type { FunctionLike } from 'jest-mock';
 
-interface CalledWithStackItem<T, Y extends any[]> {
-    args: MatchersOrLiterals<Y>;
-    calledWithFn: jest.Mock<T, Y>;
+interface CalledWithStackItem<T extends FunctionLike> {
+    args: MatchersOrLiterals<[...Parameters<T>]>;
+    calledWithFn: jest.Mock<T>;
 }
 
 interface JestAsymmetricMatcher {
@@ -13,11 +15,11 @@ function isJestAsymmetricMatcher(obj: any): obj is JestAsymmetricMatcher {
     return !!obj && typeof obj === 'object' && 'asymmetricMatch' in obj && typeof obj.asymmetricMatch === 'function';
 }
 
-const checkCalledWith = <T, Y extends any[]>(
-    calledWithStack: CalledWithStackItem<T, Y>[],
-    actualArgs: Y,
-    fallbackMockImplementation?: (...args: Y) => T
-): T => {
+const checkCalledWith = <T extends FunctionLike>(
+    calledWithStack: CalledWithStackItem<T>[],
+    actualArgs: [...Parameters<T>],
+    fallbackMockImplementation?: T
+): ReturnType<T> => {
     const calledWithInstance = calledWithStack.find((instance) =>
         instance.args.every((matcher, i) => {
             if (matcher instanceof Matcher) {
@@ -32,26 +34,26 @@ const checkCalledWith = <T, Y extends any[]>(
         })
     );
 
-    // @ts-ignore cannot return undefined, but this will fail the test if there is an expectation which is what we want
     return calledWithInstance
         ? calledWithInstance.calledWithFn(...actualArgs)
         : fallbackMockImplementation && fallbackMockImplementation(...actualArgs);
 };
 
-export const calledWithFn = <T, Y extends any[]>({
+export const calledWithFn = <T extends FunctionLike>({
     fallbackMockImplementation,
-}: { fallbackMockImplementation?: (...args: Y) => T } = {}): CalledWithMock<T, Y> => {
-    const fn: jest.Mock<T, Y> = jest.fn(fallbackMockImplementation);
-    let calledWithStack: CalledWithStackItem<T, Y>[] = [];
+}: { fallbackMockImplementation?: T } = {}): CalledWithMock<T> => {
+    const fn = jest.fn(fallbackMockImplementation);
+    let calledWithStack: CalledWithStackItem<T>[] = [];
 
-    (fn as CalledWithMock<T, Y>).calledWith = (...args) => {
+    (fn as CalledWithMock<T>).calledWith = (...args) => {
         // We create new function to delegate any interactions (mockReturnValue etc.) to for this set of args.
         // If that set of args is matched, we just call that jest.fn() for the result.
         const calledWithFn = jest.fn(fallbackMockImplementation);
         const mockImplementation = fn.getMockImplementation();
         if (!mockImplementation || mockImplementation === fallbackMockImplementation) {
             // Our original function gets a mock implementation which handles the matching
-            fn.mockImplementation((...args: Y) => checkCalledWith(calledWithStack, args, fallbackMockImplementation));
+            // @ts-expect-error '(...args: any) => ReturnType<T>' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'FunctionLike'.
+            fn.mockImplementation((...args) => checkCalledWith(calledWithStack, args, fallbackMockImplementation));
             calledWithStack = [];
         }
         calledWithStack.unshift({ args, calledWithFn });
@@ -59,7 +61,7 @@ export const calledWithFn = <T, Y extends any[]>({
         return calledWithFn;
     };
 
-    return fn as CalledWithMock<T, Y>;
+    return fn as CalledWithMock<T>;
 };
 
 export default calledWithFn;

--- a/src/Matchers.spec.ts
+++ b/src/Matchers.spec.ts
@@ -43,7 +43,6 @@ describe('Matchers', () => {
             const f = jest.fn();
             f(undefined);
 
-            // @ts-ignore
             console.info(f.mock);
 
             expect(f).toHaveBeenCalledWith(any());
@@ -60,17 +59,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for number', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyString().asymmetricMatch(123)).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyString().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyString().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -85,17 +84,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for string', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyNumber().asymmetricMatch('123')).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyNumber().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyNumber().asymmetricMatch(undefined)).toBe(false);
         });
 
@@ -114,17 +113,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for string', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyBoolean().asymmetricMatch('true')).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyBoolean().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyBoolean().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -135,17 +134,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for string', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyFunction().asymmetricMatch('true')).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyFunction().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyFunction().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -156,17 +155,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for string', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySymbol().asymmetricMatch('123')).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySymbol().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySymbol().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -215,17 +214,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for object', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyArray().asymmetricMatch({})).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignored
+            // @ts-expect-errord
             expect(anyArray().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyArray().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -242,17 +241,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for object', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyMap().asymmetricMatch({})).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyMap().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anyMap().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -269,17 +268,17 @@ describe('Matchers', () => {
         });
 
         test('returns false for object', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySet().asymmetricMatch({})).toBe(false);
         });
 
         test('returns false for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySet().asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(anySet().asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -316,17 +315,17 @@ describe('Matchers', () => {
         });
 
         test('returns false when not a map', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(arrayIncludes('val3').asymmetricMatch({})).toBe(false);
         });
 
         test('returns false when for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(arrayIncludes('val3').asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false when for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(arrayIncludes('val3').asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -341,17 +340,17 @@ describe('Matchers', () => {
         });
 
         test('returns false when not a map', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(mapHas('val3').asymmetricMatch({})).toBe(false);
         });
 
         test('returns false when for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(mapHas('val3').asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false when for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(mapHas('val3').asymmetricMatch(undefined)).toBe(false);
         });
     });
@@ -366,17 +365,17 @@ describe('Matchers', () => {
         });
 
         test('returns false when not a set', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(setHas('val3').asymmetricMatch({})).toBe(false);
         });
 
         test('returns false when for null', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(setHas('val3').asymmetricMatch(null)).toBe(false);
         });
 
         test('returns false when for undefined', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(setHas('val3').asymmetricMatch(undefined)).toBe(false);
         });
     });

--- a/src/Matchers.spec.ts
+++ b/src/Matchers.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import {
     any,
     anyArray,

--- a/src/Matchers.ts
+++ b/src/Matchers.ts
@@ -1,7 +1,15 @@
+
 export type MatcherFn<T> = (actualValue: T) => boolean;
 
+export interface MatcherLike<T> {
+    asymmetricMatch(other: unknown): boolean;
+    toString(): string;
+    getExpectedType?(): string;
+    toAsymmetricMatcher?(): string;
+}
+
 // needs to be a class so we can instanceof
-export class Matcher<T> {
+export class Matcher<T> implements MatcherLike<T> {
     $$typeof: symbol;
     inverse?: boolean;
 
@@ -31,7 +39,7 @@ export class CaptorMatcher<T> {
         this.$$typeof = Symbol.for('jest.asymmetricMatcher');
 
         this.asymmetricMatch = (actualValue: T) => {
-            // @ts-ignore
+            // @ts-expect-error
             this.value = actualValue;
             this.values.push(actualValue);
             return true;
@@ -55,7 +63,7 @@ export interface MatcherCreator<T, E = T> {
     (expectedValue?: E): Matcher<T>;
 }
 
-export type MatchersOrLiterals<Y extends any[]> = { [K in keyof Y]: Matcher<Y[K]> | Y[K] };
+export type MatchersOrLiterals<Y extends any[]> = { [K in keyof Y]: MatcherLike<Y[K]> | Y[K]  };
 
 export const any: MatcherCreator<any> = () => new Matcher(() => true, 'any()');
 export const anyBoolean: MatcherCreator<boolean> = () =>

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -2,6 +2,8 @@ import mock, { mockClear, mockDeep, mockReset, mockFn, JestMockExtended } from '
 import { anyNumber } from './Matchers';
 import calledWithFn from './CalledWithFn';
 import { MockProxy } from './Mock';
+import { describe, expect, jest, test } from '@jest/globals';
+import { fail } from 'assert';
 
 interface MockInt {
     id: number;
@@ -248,14 +250,20 @@ describe('jest-mock-extended', () => {
 
         test('Support jest matcher', () => {
             const mockObj = mock<MockInt>();
-            mockObj.getSomethingWithArgs.calledWith(expect.anything(), expect.anything()).mockReturnValue(3);
+            mockObj.getSomethingWithArgs
+                // @ts-expect-error Type 'AsymmetricMatcher_2' is missing the following properties from type 'Matcher<number>': $$typeof, description
+                .calledWith(expect.anything(), expect.anything())
+                .mockReturnValue(3);
 
             expect(mockObj.getSomethingWithArgs(1, 2)).toBe(3);
         });
 
         test('Suport mix Matchers with literals and with jest matcher', () => {
             const mockObj = mock<MockInt>();
-            mockObj.getSomethingWithMoreArgs.calledWith(anyNumber(), expect.anything(), 3).mockReturnValue(4);
+            mockObj.getSomethingWithMoreArgs
+                // @ts-expect-error Type 'AsymmetricMatcher_2' is not assignable to type 'number | Matcher<number>'
+                .calledWith(anyNumber(), expect.anything(), 3)
+                .mockReturnValue(4);
 
             expect(mockObj.getSomethingWithMoreArgs(1, 2, 3)).toBe(4);
             expect(mockObj.getSomethingWithMoreArgs(1, 2, 4)).toBeUndefined;

--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -119,6 +119,14 @@ describe('jest-mock-extended', () => {
         expect(mockObj.getSomethingWithArgs).toBeCalledWith(1, 2);
     });
 
+    test('Can mock implementation of method', () => {
+        const mockObj = mock<MockInt>();
+        mockObj.getSomethingWithArgs.mockImplementation((arg1, arg2) => {
+            return arg1 + arg2;
+        })
+        expect(mockObj.getSomethingWithArgs(1, 2)).toBe(3);
+    });
+
     test('Can specify calledWith', () => {
         const mockObj = mock<MockInt>();
         mockObj.getSomethingWithArgs.calledWith(1, 2).mockReturnValue(1);
@@ -212,7 +220,7 @@ describe('jest-mock-extended', () => {
         test('does not match when one arg does not match Matcher', () => {
             const mockObj = mock<MockInt>();
             mockObj.getSomethingWithArgs.calledWith(anyNumber(), anyNumber()).mockReturnValue(3);
-            // @ts-ignore
+            // @ts-expect-error
             expect(mockObj.getSomethingWithArgs('1', 2)).toBe(undefined);
         });
 
@@ -251,7 +259,6 @@ describe('jest-mock-extended', () => {
         test('Support jest matcher', () => {
             const mockObj = mock<MockInt>();
             mockObj.getSomethingWithArgs
-                // @ts-expect-error Type 'AsymmetricMatcher_2' is missing the following properties from type 'Matcher<number>': $$typeof, description
                 .calledWith(expect.anything(), expect.anything())
                 .mockReturnValue(3);
 
@@ -261,7 +268,6 @@ describe('jest-mock-extended', () => {
         test('Suport mix Matchers with literals and with jest matcher', () => {
             const mockObj = mock<MockInt>();
             mockObj.getSomethingWithMoreArgs
-                // @ts-expect-error Type 'AsymmetricMatcher_2' is not assignable to type 'number | Matcher<number>'
                 .calledWith(anyNumber(), expect.anything(), 3)
                 .mockReturnValue(4);
 
@@ -491,7 +497,7 @@ describe('jest-mock-extended', () => {
             const mockPromiseObj = Promise.resolve(42);
             const mockObj = mock<MockInt>();
             mockObj.id = 17;
-            // @ts-ignore
+            // @ts-expect-error
             mockObj.then = mockPromiseObj.then.bind(mockPromiseObj);
             const promiseMockObj = Promise.resolve(mockObj);
             await promiseMockObj;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,6 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "alwaysStrict": true,
-    "types": [
-      "jest"
-    ],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
Attempts to fix https://github.com/marchaos/jest-mock-extended/issues/116

Removed `@types/jest` package.

Added `@jest/globals` as peer dependency. I'm not sure about which versions to support, but Jest 28 introduced a breaking change in `jest.Mock` type definition so I'm not confident how it would work with earlier versions.

Note that this definition is different between `@types/jest@29` and `@jest/globals@29`

The change is described in https://github.com/jestjs/jest/issues/12479
tl;dr the generic type is changed from `jest.fn<ReturnType<MyFunctionType>, Parameters<MyFunctionType>>` to `jest.fn<MyFunctionType>`

I did my best to fix the new type errors in the library but I had to add a couple of `// @ts-expect-error` comments in the process.
The new types work across internal tests and when used as a dependency in our own repo but I'm not sure if they are valid for every existing use case for this library.