### PR TITLE
perf(types): prevent immediate deep and circular resolution for deep mock

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -31,21 +31,24 @@ export interface CalledWithMock<T, Y extends any[]> extends jest.Mock<T, Y> {
 }
 
 export type MockProxy<T> = {
-    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : T[K];
-} &
-    T;
+    [K in keyof T]: T[K] extends (...args: infer A) => infer B
+                    ? T[K] & CalledWithMock<B, A>
+                    : T[K];
+};
 
 export type DeepMockProxy<T> = {
     // This supports deep mocks in the else branch
-    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> : DeepMockProxy<T[K]>;
-} &
-    T;
+    [K in keyof T]: T[K] extends (...args: infer A) => infer B
+                    ? T[K] & CalledWithMock<B, A>
+                    : T[K] & DeepMockProxy<T[K]>;
+};
 
 export type DeepMockProxyWithFuncPropSupport<T> = {
     // This supports deep mocks in the else branch
-    [K in keyof T]: T[K] extends (...args: infer A) => infer B ? CalledWithMock<B, A> & DeepMockProxy<T[K]> : DeepMockProxy<T[K]>;
-} &
-    T;
+    [K in keyof T]: T[K] extends (...args: infer A) => infer B
+                    ? T[K] & CalledWithMock<B, A> & DeepMockProxy<T[K]>
+                    : T[K] & DeepMockProxy<T[K]>;
+}
 
 export interface MockOpts {
     deep?: boolean;


### PR DESCRIPTION
Hey @marchaos :wave:, a user has opened [this](https://github.com/prisma/prisma/issues/20516) issue in Prisma, and after further investigation I pinned the performance issue to come from the `MockDeep` types provided here. We recently introduced meta types that are hidden under `symbol`. There's noting special about these types except that they can be very deep and recursive, but it's all objects/records in the end. I found that `MockDeep` caused/forced TypeScript to evaluate these types.

While this is not obvious, any intersection on a mapped type (eg. [compute](https://millsp.github.io/ts-toolbelt/modules/any_compute.html)) itself will cause the mapped type to be resolved, otherwise TS would defer that for later (eg. when you access it). So `MockDeep` was forcing resolution on very huge and recursive types in the `PrismaClient`. This PR does not make things easier to read, but does make things more efficient, by forcing resolution within the mapped type itself. Also I had to re-intersect with the original type as well to preserve the full shape, including private props which mapped types remove.

With that, I was able to compile a huge PrismaClient like before we introduced this special type metadata on the `symbol` key.