### PR TITLE
fix: allow objects as a parameter in the 'calledWith' method

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
+    "lodash.isequal": "^4.5.0",
     "ts-essentials": "^7.0.3"
   },
   "devDependencies": {
     "@types/jest": "^27.5.0",
+    "@types/lodash.isequal": "^4.5.6",
     "coveralls": "^3.1.1",
     "jest": "^29.5.0",
     "prettier": "^2.3.2",

--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -1,5 +1,6 @@
 import { CalledWithMock } from './Mock';
 import { Matcher, MatchersOrLiterals } from './Matchers';
+import isEqual from 'lodash.isequal';
 
 interface CalledWithStackItem<T, Y extends any[]> {
     args: MatchersOrLiterals<Y>;
@@ -28,7 +29,7 @@ const checkCalledWith = <T, Y extends any[]>(
                 return matcher.asymmetricMatch(actualArgs[i]);
             }
 
-            return actualArgs[i] === matcher;
+            return isEqual(actualArgs[i], matcher);
         })
     );
 


### PR DESCRIPTION
The ["Features"](https://github.com/marchaos/jest-mock-extended#features) section of the README says:
> calledWith() extension to provide argument specific expectations, which works for objects and functions.

but the `calledWith` extension does not match object parameters correctly, as per Issue #118, so this is to address that.